### PR TITLE
Add combination test case

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+# DevContainer image
+FROM python:3.9-slim
+
+RUN \
+    adduser --system --disabled-password --shell /bin/bash --home /home/vscode vscode && \
+    apt-get clean
+
+RUN \
+    # dev setup
+    apt update && \
+    apt-get install sudo jq git bash-completion -y && \
+    pip install --no-cache-dir --upgrade pip flake8 black faker ipykernel && \
+    usermod -aG sudo vscode && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo '. /etc/bash_completion' >> /home/vscode/.bashrc && \
+    echo 'export PS1="\[\e[32;1m\]\u\[\e[m\]@\[\e[34;1m\]\H\[\e[m\]:\[\e[33;1m\]\w\[\e[m\]$ "' >> /home/vscode/.bashrc && \
+    apt-get clean
+
+RUN \
+    # networkx + plot(matplotlib) + dot(graphviz)
+    sudo apt-get install gcc graphviz libgraphviz-dev -y && \
+    pip install --no-cache-dir networkx[default] matplotlib pygraphviz && \
+    # install PyQt5 for GUI windows (supported in VSCode debugger)
+    sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev && \
+    pip install --no-cache-dir pyqt5 && \
+    # add pydantic for model structure, yaml parsing, and pytests
+    pip install --no-cache-dir pydantic pyyaml pytest && \
+    apt-get clean
+
+USER vscode
+ENV PATH ${PATH}:/home/vscode/.local/bin
+
+CMD tail -f /dev/null

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "Development",
+	"dockerComposeFile": "docker-compose.yaml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"remoteEnv": {
+		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+	},
+	"customizations": {
+		"settings": {
+			"python.pythonPath": "/usr/local/bin/python"
+		},
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.black-formatter",
+				"ms-toolsai.jupyter",
+			]
+		}
+	}
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: ./.devcontainer/Dockerfile
+    environment:
+      - DISPLAY  # open guis using xserver
+    volumes:
+      - ..:/workspaces/orcinus-test-cases:cached
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw  # open guis using xserver
+volumes:
+  docker_data:

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -9,5 +9,3 @@ services:
     volumes:
       - ..:/workspaces/orcinus-test-cases:cached
       - /tmp/.X11-unix:/tmp/.X11-unix:rw  # open guis using xserver
-volumes:
-  docker_data:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.pytest_cache
+.trash

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,41 @@
+{
+    "editor.formatOnPaste": false,
+    "editor.formatOnSave": true,
+    "notebook.formatOnSave.enabled": true,
+    "editor.rulers": [
+        88
+    ],
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "[markdown]": {
+        "editor.defaultFormatter": null
+    },
+    "files.autoSave": "off",
+    "jupyter.kernels.excludePythonEnvironments": [
+        "/bin/python3",
+        "/usr/bin/python3",
+        "/usr/local/bin/python"
+    ],
+    "python.defaultInterpreterPath": "/usr/local/bin/python3",
+    "launch": {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Python: Current File",
+                "type": "debugpy",
+                "request": "launch",
+                "console": "integratedTerminal",
+                "justMyCode": false,
+                "cwd": "${fileDirname}",
+                "program": "${file}"
+            }
+        ]
+    },
+    "python.testing.pytestArgs": [
+        "tests_pipeline_use_cases"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.testing.autoTestDiscoverOnSaveEnabled": false
+}

--- a/tests_pipeline_use_cases/test_basic.py
+++ b/tests_pipeline_use_cases/test_basic.py
@@ -1,0 +1,264 @@
+from utils import (
+    Collection,
+    Mapper,
+    Input,
+    PodRun,
+    Container,
+    simulate_orchestration,
+)
+
+
+def test_combination():
+    # combination style transfer: 2 images, 2 images, cartesian product, 4 workers
+
+    def map_combine1(parents, children, mapper):
+        # cartesian (combination) file product, assumes N parents and 1 child
+        import itertools
+
+        input_sets = [
+            [f"{p_name}/{f}" for f in c.files]
+            for p_name, p in parents.items()
+            for c in p["collections"]
+        ]
+        collections = [{"files": list(c)} for c in itertools.product(*input_sets)]
+        expected_files = list(children.values())[0]["expected_collection"].files
+        # specific logic for name mapping
+        map_name = lambda fname, options: (
+            options[0] if "paint" in fname else options[1]
+        )
+        mapped_names = [
+            {f: map_name(f, expected_files) for f in c["files"]} for c in collections
+        ]
+        return dict(collections=collections, mapped_names=mapped_names)
+
+    user_pipeline = {
+        "pipeline_settings": {
+            "store": "/pipeline1",
+            "cpu_limit": 16,
+            "memory_limit": "64GiB",
+        },
+        "nodes": {
+            "input1": Input(
+                collections=[
+                    Collection(
+                        files=[
+                            "a/b/c/paint-0.png",
+                            "a/b/c/paint-1.png",
+                        ]
+                    )
+                ]
+            ),
+            "input2": Input(
+                collections=[
+                    Collection(
+                        files=[
+                            "a/b/c/person-0.png",
+                            "a/b/c/person-1.png",
+                        ]
+                    )
+                ]
+            ),
+            "map1": Mapper(
+                method=map_combine1,
+            ),
+            "pod1": PodRun(
+                expected_collection=Collection(
+                    files=["/main/painting.png", "/main/photo.png"]
+                ),
+                output_dir="/main/output",
+                max_workers=4,
+                collections=[
+                    Collection(
+                        files=[
+                            "styled.png",
+                        ]
+                    )
+                ],
+            ),
+        },
+        "streams": """
+            input1 -> map1
+            input2 -> map1
+            map1 -> pod1
+        """,
+    }
+    expected_run_sequence = {
+        0: {
+            "containers": [
+                Container(
+                    name="map1",
+                    memory_limit="100MiB",
+                    cpu_limit=0.25,
+                    file_mounts={
+                        "/pipeline1/input1/a/b/c/paint-0.png": {
+                            "mount_dest": "/input/a/b/c/paint-0.png",
+                            "mount_mode": "ro",
+                        },
+                        "/pipeline1/input2/a/b/c/person-0.png": {
+                            "mount_dest": "/input/a/b/c/person-0.png",
+                            "mount_mode": "ro",
+                        },
+                        "/pipeline1/input1/a/b/c/paint-1.png": {
+                            "mount_dest": "/input/a/b/c/paint-1.png",
+                            "mount_mode": "ro",
+                        },
+                        "/pipeline1/input2/a/b/c/person-1.png": {
+                            "mount_dest": "/input/a/b/c/person-1.png",
+                            "mount_mode": "ro",
+                        },
+                    },
+                    dir_mounts={
+                        "/pipeline1/map1": {
+                            "mount_dest": "/ouput",
+                            "mount_mode": "rw",
+                        }
+                    },
+                )
+            ],
+            "store": """
+            pipeline1:
+              input1:
+                a:
+                  b:
+                    c:
+                      paint-0.png:
+                      paint-1.png:
+              input2:
+                a:
+                  b:
+                    c:
+                      person-0.png:
+                      person-1.png:
+              map1:
+                a:
+                  b:
+                    c:
+                      paint-0.png:
+                      paint-1.png:
+                      person-0.png:
+                      person-1.png:
+            """,
+        },
+        1: {
+            "containers": [
+                Container(
+                    name="pod1-w0",
+                    memory_limit="1GiB",
+                    cpu_limit=1,
+                    file_mounts={
+                        "/pipeline1/map1/a/b/c/paint-0.png": {
+                            "mount_dest": "/main/painting.png",
+                            "mount_mode": "ro",
+                        },
+                        "/pipeline1/map1/a/b/c/person-0.png": {
+                            "mount_dest": "/main/photo.png",
+                            "mount_mode": "ro",
+                        },
+                    },
+                    dir_mounts={
+                        "/pipeline1/pod1/w0": {
+                            "mount_dest": "/main/ouput",
+                            "mount_mode": "rw",
+                        }
+                    },
+                ),
+                Container(
+                    name="pod1-w1",
+                    memory_limit="1GiB",
+                    cpu_limit=1,
+                    file_mounts={
+                        "/pipeline1/map1/a/b/c/paint-0.png": {
+                            "mount_dest": "/main/painting.png",
+                            "mount_mode": "ro",
+                        },
+                        "/pipeline1/map1/a/b/c/person-1.png": {
+                            "mount_dest": "/main/photo.png",
+                            "mount_mode": "ro",
+                        },
+                    },
+                    dir_mounts={
+                        "/pipeline1/pod1/w1": {
+                            "mount_dest": "/main/ouput",
+                            "mount_mode": "rw",
+                        }
+                    },
+                ),
+                Container(
+                    name="pod1-w2",
+                    memory_limit="1GiB",
+                    cpu_limit=1,
+                    file_mounts={
+                        "/pipeline1/map1/a/b/c/paint-1.png": {
+                            "mount_dest": "/main/painting.png",
+                            "mount_mode": "ro",
+                        },
+                        "/pipeline1/map1/a/b/c/person-0.png": {
+                            "mount_dest": "/main/photo.png",
+                            "mount_mode": "ro",
+                        },
+                    },
+                    dir_mounts={
+                        "/pipeline1/pod1/w2": {
+                            "mount_dest": "/main/ouput",
+                            "mount_mode": "rw",
+                        }
+                    },
+                ),
+                Container(
+                    name="pod1-w3",
+                    memory_limit="1GiB",
+                    cpu_limit=1,
+                    file_mounts={
+                        "/pipeline1/map1/a/b/c/paint-1.png": {
+                            "mount_dest": "/main/painting.png",
+                            "mount_mode": "ro",
+                        },
+                        "/pipeline1/map1/a/b/c/person-1.png": {
+                            "mount_dest": "/main/photo.png",
+                            "mount_mode": "ro",
+                        },
+                    },
+                    dir_mounts={
+                        "/pipeline1/pod1/w3": {
+                            "mount_dest": "/main/ouput",
+                            "mount_mode": "rw",
+                        }
+                    },
+                ),
+            ],
+            "store": """
+            pipeline1:
+              input1:
+                a:
+                  b:
+                    c:
+                      paint-0.png:
+                      paint-1.png:
+              input2:
+                a:
+                  b:
+                    c:
+                      person-0.png:
+                      person-1.png:
+              map1:
+                a:
+                  b:
+                    c:
+                      paint-0.png:
+                      paint-1.png:
+                      person-0.png:
+                      person-1.png:
+              pod1:
+                w0:
+                  styled.png:
+                w1:
+                  styled.png:
+                w2:
+                  styled.png:
+                w3:
+                  styled.png:
+            """,
+        },
+    }
+
+    assert simulate_orchestration(user_pipeline) == expected_run_sequence

--- a/tests_pipeline_use_cases/test_basic.py
+++ b/tests_pipeline_use_cases/test_basic.py
@@ -107,12 +107,6 @@ def test_combination():
                             "mount_mode": "ro",
                         },
                     },
-                    dir_mounts={
-                        "/pipeline1/map1": {
-                            "mount_dest": "/ouput",
-                            "mount_mode": "rw",
-                        }
-                    },
                 )
             ],
             "store": """
@@ -129,14 +123,6 @@ def test_combination():
                     c:
                       person-0.png:
                       person-1.png:
-              map1:
-                a:
-                  b:
-                    c:
-                      paint-0.png:
-                      paint-1.png:
-                      person-0.png:
-                      person-1.png:
             """,
         },
         1: {
@@ -146,11 +132,11 @@ def test_combination():
                     memory_limit="1GiB",
                     cpu_limit=1,
                     file_mounts={
-                        "/pipeline1/map1/a/b/c/paint-0.png": {
+                        "/pipeline1/input1/a/b/c/paint-0.png": {
                             "mount_dest": "/main/painting.png",
                             "mount_mode": "ro",
                         },
-                        "/pipeline1/map1/a/b/c/person-0.png": {
+                        "/pipeline1/input2/a/b/c/person-0.png": {
                             "mount_dest": "/main/photo.png",
                             "mount_mode": "ro",
                         },
@@ -167,11 +153,11 @@ def test_combination():
                     memory_limit="1GiB",
                     cpu_limit=1,
                     file_mounts={
-                        "/pipeline1/map1/a/b/c/paint-0.png": {
+                        "/pipeline1/input1/a/b/c/paint-0.png": {
                             "mount_dest": "/main/painting.png",
                             "mount_mode": "ro",
                         },
-                        "/pipeline1/map1/a/b/c/person-1.png": {
+                        "/pipeline1/input2/a/b/c/person-1.png": {
                             "mount_dest": "/main/photo.png",
                             "mount_mode": "ro",
                         },
@@ -188,11 +174,11 @@ def test_combination():
                     memory_limit="1GiB",
                     cpu_limit=1,
                     file_mounts={
-                        "/pipeline1/map1/a/b/c/paint-1.png": {
+                        "/pipeline1/input1/a/b/c/paint-1.png": {
                             "mount_dest": "/main/painting.png",
                             "mount_mode": "ro",
                         },
-                        "/pipeline1/map1/a/b/c/person-0.png": {
+                        "/pipeline1/input2/a/b/c/person-0.png": {
                             "mount_dest": "/main/photo.png",
                             "mount_mode": "ro",
                         },
@@ -209,11 +195,11 @@ def test_combination():
                     memory_limit="1GiB",
                     cpu_limit=1,
                     file_mounts={
-                        "/pipeline1/map1/a/b/c/paint-1.png": {
+                        "/pipeline1/input1/a/b/c/paint-1.png": {
                             "mount_dest": "/main/painting.png",
                             "mount_mode": "ro",
                         },
-                        "/pipeline1/map1/a/b/c/person-1.png": {
+                        "/pipeline1/input2/a/b/c/person-1.png": {
                             "mount_dest": "/main/photo.png",
                             "mount_mode": "ro",
                         },
@@ -238,14 +224,6 @@ def test_combination():
                 a:
                   b:
                     c:
-                      person-0.png:
-                      person-1.png:
-              map1:
-                a:
-                  b:
-                    c:
-                      paint-0.png:
-                      paint-1.png:
                       person-0.png:
                       person-1.png:
               pod1:

--- a/tests_pipeline_use_cases/utils.py
+++ b/tests_pipeline_use_cases/utils.py
@@ -1,0 +1,70 @@
+from pydantic import BaseModel
+from typing import List, Dict, Any, Callable, Literal
+from typing_extensions import TypedDict
+
+
+# no mapper -> mapper
+def default_map(parents, children, mapper):
+    # hadamard (element-wise) file product
+    # assumes N parents, 1 child, and parent order matches expected_collection order
+    input_sets = [
+        [f"{p_name}/{f}" for f in c.files]
+        for p_name, p in parents.items()
+        for c in p["collections"]
+    ]
+    collections = [{"files": list(c)} for c in zip(*input_sets)]
+    expected_files = list(children.values())[0]["expected_collection"].files
+    mapped_names = [
+        {f: mapped_name for f, mapped_name in zip(c["files"], expected_files)}
+        for c in collections
+    ]
+    return dict(collections=collections, mapped_names=mapped_names)
+
+
+class Collection(BaseModel):
+    env_vars: List[Dict[str, Any]] = []
+    files: List[str] = []
+
+
+class Mapper(BaseModel):
+    method: Callable = default_map
+    input_dir: str = "/input"
+    output_dir: str = "/output"
+    memory_limit: str = "100MiB"
+    cpu_limit: float = 0.25
+    modify_input: bool = False
+
+
+class Input(BaseModel):
+    collections: List[Collection]
+
+
+class PodJob(BaseModel):
+    expected_collection: Collection
+    output_dir: str = "/output"
+    memory_limit: str = "1GiB"
+    cpu_limit: float = 1.0
+    max_workers: int = 1
+
+
+class PodRun(PodJob):
+    collections: List[Collection]
+
+
+class Container(BaseModel):
+    name: str
+    env_vars: Dict[str, Any] = {}
+    file_mounts: Dict[
+        str,
+        TypedDict("Mount", {"mount_dest": str, "mount_mode": Literal["ro", "rw"]}),
+    ] = {}
+    dir_mounts: Dict[
+        str,
+        TypedDict("Mount", {"mount_dest": str, "mount_mode": Literal["ro", "rw"]}),
+    ] = {}
+    memory_limit: str
+    cpu_limit: float
+
+
+def simulate_orchestration(user_pipeline):
+    raise Exception("Not implemented.")


### PR DESCRIPTION
This PR adds the following features:
- DevContainer environment with support for debugging and testing in VSCode
- Support for launching GUI windows (useful when visualizing NetworkX graphs)
- Test case `test_combination` which represents a simple cartesian product file case
- A set of standard pydantic models for us to use in describing test cases + a default map for `Mapper` using a Hadamard product (element-wise)